### PR TITLE
Voting with unlimited NFTs

### DIFF
--- a/programs/nft-voter/src/instructions/cast_nft_vote.rs
+++ b/programs/nft-voter/src/instructions/cast_nft_vote.rs
@@ -9,6 +9,9 @@ use spl_governance_tools::account::create_and_serialize_account_signed;
 /// This instruction updates VoterWeightRecord which is valid for the current Slot and the target Proposal only
 /// and hance the instruction has to be executed inside the same transaction as spl-gov.CastVote
 ///
+/// CastNftVote is accumulative and can be invoked using several transactions if voter owns more than 5 NFTs to calculate total voter_weight
+/// In this scenario only the last CastNftVote should be bundled  with spl-gov.CastVote in the same transaction
+///
 /// CastNftVote instruction and NftVoteRecord are not directional. They don't record vote choice (ex Yes/No)
 /// VoteChoice is recorded by spl-gov in VoteRecord and this CastNftVote only tracks voting NFTs
 ///

--- a/programs/nft-voter/src/instructions/cast_nft_vote.rs
+++ b/programs/nft-voter/src/instructions/cast_nft_vote.rs
@@ -77,6 +77,9 @@ pub fn cast_nft_vote<'a, 'b, 'c, 'info>(
             NftVoterError::NftAlreadyVoted
         );
 
+        // Note: proposal.governing_token_mint must match voter_weight_record.governing_token_mint
+        // We don't verify it here because spl-gov does the check in cast_vote
+        // and it would reject voter_weight_record if governing_token_mint doesn't match
         let nft_vote_record = NftVoteRecord {
             account_discriminator: NftVoteRecord::ACCOUNT_DISCRIMINATOR,
             proposal,

--- a/programs/nft-voter/src/instructions/relinquish_nft_vote.rs
+++ b/programs/nft-voter/src/instructions/relinquish_nft_vote.rs
@@ -113,5 +113,7 @@ pub fn relinquish_nft_vote(ctx: Context<RelinquishNftVote>) -> Result<()> {
     voter_weight_record.voter_weight = 0;
     voter_weight_record.voter_weight_expiry = Some(0);
 
+    voter_weight_record.weight_action_target = None;
+
     Ok(())
 }

--- a/programs/nft-voter/src/instructions/update_voter_weight_record.rs
+++ b/programs/nft-voter/src/instructions/update_voter_weight_record.rs
@@ -7,9 +7,9 @@ use itertools::Itertools;
 /// This instruction updates VoterWeightRecord which is valid for the current Slot and the given target action only
 /// and hance the instruction has to be executed inside the same transaction as the corresponding spl-gov instruction
 ///
-/// Note: UpdateVoterWeight is not accumulative the same way as CastNftVote and hence voter_weight for non voting scenarios
+/// Note: UpdateVoterWeight is not cumulative the same way as CastNftVote and hence voter_weight for non voting scenarios
 /// can only be used with max 5 NFTs due to Solana transaction size limit
-/// It could be supported in future version by introducing bookkeeping account which would track the NFTs
+/// It could be supported in future version by introducing bookkeeping accounts to track the NFTs
 /// which were already used to calculate the total weight
 #[derive(Accounts)]
 #[instruction(voter_weight_action:VoterWeightAction)]

--- a/programs/nft-voter/src/instructions/update_voter_weight_record.rs
+++ b/programs/nft-voter/src/instructions/update_voter_weight_record.rs
@@ -6,6 +6,11 @@ use itertools::Itertools;
 /// Updates VoterWeightRecord to evaluate governance power for non voting use cases: CreateProposal, CreateGovernance etc...
 /// This instruction updates VoterWeightRecord which is valid for the current Slot and the given target action only
 /// and hance the instruction has to be executed inside the same transaction as the corresponding spl-gov instruction
+///
+/// Note: UpdateVoterWeight is not accumulative the same way as CastNftVote and hence voter_weight for non voting scenarios
+/// can only be used with max 5 NFTs due to Solana transaction size limit
+/// It could be supported in future version by introducing bookkeeping account which would track the NFTs
+/// which were already used to calculate the total weight
 #[derive(Accounts)]
 #[instruction(voter_weight_action:VoterWeightAction)]
 pub struct UpdateVoterWeightRecord<'info> {

--- a/programs/nft-voter/tests/cast_nft_vote.rs
+++ b/programs/nft-voter/tests/cast_nft_vote.rs
@@ -3,6 +3,7 @@ use gpl_nft_voter::error::NftVoterError;
 use gpl_nft_voter::state::*;
 use program_test::token_metadata_test::CreateNftArgs;
 use program_test::{nft_voter_test::NftVoterTest, tools::assert_nft_voter_err};
+
 use solana_program_test::*;
 use solana_sdk::transport::TransportError;
 
@@ -789,6 +790,108 @@ async fn test_cast_nft_vote_with_no_nft_error() -> Result<(), TransportError> {
 
     // Assert
     assert_nft_voter_err(err, NftVoterError::InvalidNftAmount);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cast_nft_vote_with_max_5_nfts() -> Result<(), TransportError> {
+    // Arrange
+    let mut nft_voter_test = NftVoterTest::start_new().await;
+
+    let realm_cookie = nft_voter_test.governance.with_realm().await?;
+
+    let registrar_cookie = nft_voter_test.with_registrar(&realm_cookie).await?;
+
+    let nft_collection_cookie = nft_voter_test.token_metadata.with_nft_collection().await?;
+
+    let max_voter_weight_record_cookie = nft_voter_test
+        .with_max_voter_weight_record(&registrar_cookie)
+        .await?;
+
+    nft_voter_test
+        .with_collection(
+            &registrar_cookie,
+            &nft_collection_cookie,
+            &max_voter_weight_record_cookie,
+            Some(ConfigureCollectionArgs {
+                weight: 10,
+                size: 20,
+            }),
+        )
+        .await?;
+
+    let voter_cookie = nft_voter_test.bench.with_wallet().await;
+
+    let voter_token_owner_record_cookie = nft_voter_test
+        .governance
+        .with_token_owner_record(&realm_cookie, &voter_cookie)
+        .await?;
+
+    let voter_weight_record_cookie = nft_voter_test
+        .with_voter_weight_record(&registrar_cookie, &voter_cookie)
+        .await?;
+
+    let proposal_cookie = nft_voter_test
+        .governance
+        .with_proposal(&realm_cookie)
+        .await?;
+
+    let mut nft_cookies = vec![];
+
+    for _ in 0..5 {
+        nft_voter_test.bench.advance_clock().await;
+        let nft_cookie = nft_voter_test
+            .token_metadata
+            .with_nft_v2(&nft_collection_cookie, &voter_cookie, None)
+            .await?;
+
+        nft_cookies.push(nft_cookie)
+    }
+
+    nft_voter_test.bench.advance_clock().await;
+    let clock = nft_voter_test.bench.get_clock().await;
+
+    // Act
+    let nft_vote_record_cookies = nft_voter_test
+        .cast_nft_vote(
+            &registrar_cookie,
+            &voter_weight_record_cookie,
+            &max_voter_weight_record_cookie,
+            &proposal_cookie,
+            &voter_cookie,
+            &voter_token_owner_record_cookie,
+            &nft_cookies.iter().collect::<Vec<_>>(),
+        )
+        .await?;
+
+    // Assert
+    let nft_vote_record1 = nft_voter_test
+        .get_nf_vote_record_account(&nft_vote_record_cookies[0].address)
+        .await;
+
+    assert_eq!(nft_vote_record_cookies[0].account, nft_vote_record1);
+
+    let nft_vote_record2 = nft_voter_test
+        .get_nf_vote_record_account(&nft_vote_record_cookies[1].address)
+        .await;
+
+    assert_eq!(nft_vote_record_cookies[1].account, nft_vote_record2);
+
+    let voter_weight_record = nft_voter_test
+        .get_voter_weight_record(&voter_weight_record_cookie.address)
+        .await;
+
+    assert_eq!(voter_weight_record.voter_weight, 50);
+    assert_eq!(voter_weight_record.voter_weight_expiry, Some(clock.slot));
+    assert_eq!(
+        voter_weight_record.weight_action,
+        Some(VoterWeightAction::CastVote.into())
+    );
+    assert_eq!(
+        voter_weight_record.weight_action_target,
+        Some(proposal_cookie.address)
+    );
 
     Ok(())
 }

--- a/programs/nft-voter/tests/cast_nft_vote.rs
+++ b/programs/nft-voter/tests/cast_nft_vote.rs
@@ -2,7 +2,7 @@ use crate::program_test::nft_voter_test::ConfigureCollectionArgs;
 use gpl_nft_voter::error::NftVoterError;
 use gpl_nft_voter::state::*;
 use program_test::token_metadata_test::CreateNftArgs;
-use program_test::{nft_voter_test::NftVoterTest, tools::assert_nft_voter_err};
+use program_test::{nft_voter_test::*, tools::assert_nft_voter_err};
 
 use solana_program_test::*;
 use solana_sdk::transport::TransportError;
@@ -70,6 +70,7 @@ async fn test_cast_nft_vote() -> Result<(), TransportError> {
             &voter_cookie,
             &voter_token_owner_record_cookie,
             &[&nft_cookie1],
+            None,
         )
         .await?;
 
@@ -164,6 +165,7 @@ async fn test_cast_nft_vote_with_multiple_nfts() -> Result<(), TransportError> {
             &voter_cookie,
             &voter_token_owner_record_cookie,
             &[&nft_cookie1, &nft_cookie2],
+            None,
         )
         .await?;
 
@@ -252,6 +254,7 @@ async fn test_cast_nft_vote_with_nft_already_voted_error() -> Result<(), Transpo
             &voter_cookie,
             &voter_token_owner_record_cookie,
             &[&nft_cookie1],
+            None,
         )
         .await?;
 
@@ -268,6 +271,7 @@ async fn test_cast_nft_vote_with_nft_already_voted_error() -> Result<(), Transpo
             &voter_cookie,
             &voter_token_owner_record_cookie,
             &[&nft_cookie1],
+            None,
         )
         .await
         .err()
@@ -337,6 +341,7 @@ async fn test_cast_nft_vote_invalid_voter_error() -> Result<(), TransportError> 
             &voter_cookie2,
             &voter_token_owner_record_cookie,
             &[&nft_cookie1],
+            None,
         )
         .await
         .err()
@@ -414,6 +419,7 @@ async fn test_cast_nft_vote_with_unverified_collection_error() -> Result<(), Tra
             &voter_cookie,
             &voter_token_owner_record_cookie,
             &[&nft_cookie1],
+            None,
         )
         .await
         .err()
@@ -485,6 +491,7 @@ async fn test_cast_nft_vote_with_invalid_owner_error() -> Result<(), TransportEr
             &voter_cookie,
             &voter_token_owner_record_cookie,
             &[&nft_cookie],
+            None,
         )
         .await
         .err()
@@ -556,6 +563,7 @@ async fn test_cast_nft_vote_with_invalid_collection_error() -> Result<(), Transp
             &voter_cookie,
             &voter_token_owner_record_cookie,
             &[&nft_cookie],
+            None,
         )
         .await
         .err()
@@ -640,6 +648,7 @@ async fn test_cast_nft_vote_with_invalid_metadata_error() -> Result<(), Transpor
             &voter_cookie,
             &voter_token_owner_record_cookie,
             &[&nft1_cookie],
+            None,
         )
         .await
         .err()
@@ -706,6 +715,7 @@ async fn test_cast_nft_vote_with_same_nft_error() -> Result<(), TransportError> 
             &voter_cookie,
             &voter_token_owner_record_cookie,
             &[&nft_cookie, &nft_cookie],
+            None,
         )
         .await
         .err()
@@ -783,6 +793,7 @@ async fn test_cast_nft_vote_with_no_nft_error() -> Result<(), TransportError> {
             &voter_cookie,
             &voter_token_owner_record_cookie,
             &[&nft_cookie1],
+            None,
         )
         .await
         .err()
@@ -862,6 +873,7 @@ async fn test_cast_nft_vote_with_max_5_nfts() -> Result<(), TransportError> {
             &voter_cookie,
             &voter_token_owner_record_cookie,
             &nft_cookies.iter().collect::<Vec<_>>(),
+            None,
         )
         .await?;
 
@@ -892,6 +904,308 @@ async fn test_cast_nft_vote_with_max_5_nfts() -> Result<(), TransportError> {
         voter_weight_record.weight_action_target,
         Some(proposal_cookie.address)
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cast_nft_vote_using_multiple_instructions() -> Result<(), TransportError> {
+    // Arrange
+    let mut nft_voter_test = NftVoterTest::start_new().await;
+
+    let realm_cookie = nft_voter_test.governance.with_realm().await?;
+
+    let registrar_cookie = nft_voter_test.with_registrar(&realm_cookie).await?;
+
+    let nft_collection_cookie = nft_voter_test.token_metadata.with_nft_collection().await?;
+
+    let max_voter_weight_record_cookie = nft_voter_test
+        .with_max_voter_weight_record(&registrar_cookie)
+        .await?;
+
+    nft_voter_test
+        .with_collection(
+            &registrar_cookie,
+            &nft_collection_cookie,
+            &max_voter_weight_record_cookie,
+            Some(ConfigureCollectionArgs {
+                weight: 10,
+                size: 20,
+            }),
+        )
+        .await?;
+
+    let voter_cookie = nft_voter_test.bench.with_wallet().await;
+
+    let voter_token_owner_record_cookie = nft_voter_test
+        .governance
+        .with_token_owner_record(&realm_cookie, &voter_cookie)
+        .await?;
+
+    let voter_weight_record_cookie = nft_voter_test
+        .with_voter_weight_record(&registrar_cookie, &voter_cookie)
+        .await?;
+
+    let proposal_cookie = nft_voter_test
+        .governance
+        .with_proposal(&realm_cookie)
+        .await?;
+
+    let nft_cookie1 = nft_voter_test
+        .token_metadata
+        .with_nft_v2(&nft_collection_cookie, &voter_cookie, None)
+        .await?;
+
+    nft_voter_test.bench.advance_clock().await;
+    let clock = nft_voter_test.bench.get_clock().await;
+
+    let args = CastNftVoteArgs {
+        cast_spl_gov_vote: false,
+    };
+
+    nft_voter_test
+        .cast_nft_vote(
+            &registrar_cookie,
+            &voter_weight_record_cookie,
+            &max_voter_weight_record_cookie,
+            &proposal_cookie,
+            &voter_cookie,
+            &voter_token_owner_record_cookie,
+            &[&nft_cookie1],
+            Some(args),
+        )
+        .await?;
+
+    let nft_cookie2 = nft_voter_test
+        .token_metadata
+        .with_nft_v2(&nft_collection_cookie, &voter_cookie, None)
+        .await?;
+
+    // Act
+
+    nft_voter_test
+        .cast_nft_vote(
+            &registrar_cookie,
+            &voter_weight_record_cookie,
+            &max_voter_weight_record_cookie,
+            &proposal_cookie,
+            &voter_cookie,
+            &voter_token_owner_record_cookie,
+            &[&nft_cookie2],
+            None,
+        )
+        .await?;
+
+    // Assert
+
+    let voter_weight_record = nft_voter_test
+        .get_voter_weight_record(&voter_weight_record_cookie.address)
+        .await;
+
+    assert_eq!(voter_weight_record.voter_weight, 20);
+    assert_eq!(voter_weight_record.voter_weight_expiry, Some(clock.slot));
+    assert_eq!(
+        voter_weight_record.weight_action,
+        Some(VoterWeightAction::CastVote.into())
+    );
+    assert_eq!(
+        voter_weight_record.weight_action_target,
+        Some(proposal_cookie.address)
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cast_nft_vote_using_multiple_instructions_with_nft_already_voted_error(
+) -> Result<(), TransportError> {
+    // Arrange
+    let mut nft_voter_test = NftVoterTest::start_new().await;
+
+    let realm_cookie = nft_voter_test.governance.with_realm().await?;
+
+    let registrar_cookie = nft_voter_test.with_registrar(&realm_cookie).await?;
+
+    let nft_collection_cookie = nft_voter_test.token_metadata.with_nft_collection().await?;
+
+    let max_voter_weight_record_cookie = nft_voter_test
+        .with_max_voter_weight_record(&registrar_cookie)
+        .await?;
+
+    nft_voter_test
+        .with_collection(
+            &registrar_cookie,
+            &nft_collection_cookie,
+            &max_voter_weight_record_cookie,
+            Some(ConfigureCollectionArgs {
+                weight: 10,
+                size: 20,
+            }),
+        )
+        .await?;
+
+    let voter_cookie = nft_voter_test.bench.with_wallet().await;
+
+    let voter_token_owner_record_cookie = nft_voter_test
+        .governance
+        .with_token_owner_record(&realm_cookie, &voter_cookie)
+        .await?;
+
+    let voter_weight_record_cookie = nft_voter_test
+        .with_voter_weight_record(&registrar_cookie, &voter_cookie)
+        .await?;
+
+    let proposal_cookie = nft_voter_test
+        .governance
+        .with_proposal(&realm_cookie)
+        .await?;
+
+    let nft_cookie1 = nft_voter_test
+        .token_metadata
+        .with_nft_v2(&nft_collection_cookie, &voter_cookie, None)
+        .await?;
+
+    let args = CastNftVoteArgs {
+        cast_spl_gov_vote: false,
+    };
+
+    nft_voter_test
+        .cast_nft_vote(
+            &registrar_cookie,
+            &voter_weight_record_cookie,
+            &max_voter_weight_record_cookie,
+            &proposal_cookie,
+            &voter_cookie,
+            &voter_token_owner_record_cookie,
+            &[&nft_cookie1],
+            Some(args),
+        )
+        .await?;
+
+    // Act
+
+    let err = nft_voter_test
+        .cast_nft_vote(
+            &registrar_cookie,
+            &voter_weight_record_cookie,
+            &max_voter_weight_record_cookie,
+            &proposal_cookie,
+            &voter_cookie,
+            &voter_token_owner_record_cookie,
+            &[&nft_cookie1],
+            None,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+    assert_nft_voter_err(err, NftVoterError::NftAlreadyVoted);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_cast_nft_vote_using_multiple_instructions_with_attempted_sandwiched_relinquish(
+) -> Result<(), TransportError> {
+    // Arrange
+    let mut nft_voter_test = NftVoterTest::start_new().await;
+
+    let realm_cookie = nft_voter_test.governance.with_realm().await?;
+
+    let registrar_cookie = nft_voter_test.with_registrar(&realm_cookie).await?;
+
+    let nft_collection_cookie = nft_voter_test.token_metadata.with_nft_collection().await?;
+
+    let max_voter_weight_record_cookie = nft_voter_test
+        .with_max_voter_weight_record(&registrar_cookie)
+        .await?;
+
+    nft_voter_test
+        .with_collection(
+            &registrar_cookie,
+            &nft_collection_cookie,
+            &max_voter_weight_record_cookie,
+            Some(ConfigureCollectionArgs {
+                weight: 10,
+                size: 20,
+            }),
+        )
+        .await?;
+
+    let voter_cookie = nft_voter_test.bench.with_wallet().await;
+
+    let voter_token_owner_record_cookie = nft_voter_test
+        .governance
+        .with_token_owner_record(&realm_cookie, &voter_cookie)
+        .await?;
+
+    let voter_weight_record_cookie = nft_voter_test
+        .with_voter_weight_record(&registrar_cookie, &voter_cookie)
+        .await?;
+
+    let proposal_cookie = nft_voter_test
+        .governance
+        .with_proposal(&realm_cookie)
+        .await?;
+
+    let nft_cookie1 = nft_voter_test
+        .token_metadata
+        .with_nft_v2(&nft_collection_cookie, &voter_cookie, None)
+        .await?;
+
+    let args = CastNftVoteArgs {
+        cast_spl_gov_vote: false,
+    };
+
+    // Cast vote with NFT
+    let nft_vote_record_cookies = nft_voter_test
+        .cast_nft_vote(
+            &registrar_cookie,
+            &voter_weight_record_cookie,
+            &max_voter_weight_record_cookie,
+            &proposal_cookie,
+            &voter_cookie,
+            &voter_token_owner_record_cookie,
+            &[&nft_cookie1],
+            Some(args),
+        )
+        .await?;
+
+    // Try relinquish NftVoteRecords to accumulate vote
+    nft_voter_test
+        .relinquish_nft_vote(
+            &registrar_cookie,
+            &voter_weight_record_cookie,
+            &proposal_cookie,
+            &voter_cookie,
+            &voter_token_owner_record_cookie,
+            &nft_vote_record_cookies,
+        )
+        .await?;
+
+    // Act
+
+    nft_voter_test
+        .cast_nft_vote(
+            &registrar_cookie,
+            &voter_weight_record_cookie,
+            &max_voter_weight_record_cookie,
+            &proposal_cookie,
+            &voter_cookie,
+            &voter_token_owner_record_cookie,
+            &[&nft_cookie1],
+            None,
+        )
+        .await?;
+
+    // Assert
+
+    let voter_weight_record = nft_voter_test
+        .get_voter_weight_record(&voter_weight_record_cookie.address)
+        .await;
+
+    assert_eq!(voter_weight_record.voter_weight, 10);
 
     Ok(())
 }

--- a/programs/nft-voter/tests/relinquish_nft_vote.rs
+++ b/programs/nft-voter/tests/relinquish_nft_vote.rs
@@ -61,6 +61,7 @@ async fn test_relinquish_nft_vote() -> Result<(), TransportError> {
             &voter_cookie,
             &voter_token_owner_record_cookie,
             &[&nft_cookie1],
+            None,
         )
         .await?;
 
@@ -151,6 +152,7 @@ async fn test_relinquish_nft_vote_for_proposal_in_voting_state() -> Result<(), T
             &voter_cookie,
             &voter_token_owner_record_cookie,
             &[&nft_cookie1],
+            None,
         )
         .await?;
 
@@ -252,6 +254,7 @@ async fn test_relinquish_nft_vote_for_proposal_in_voting_state_and_vote_record_e
             &voter_cookie,
             &voter_token_owner_record_cookie,
             &[&nft_cookie1],
+            None,
         )
         .await?;
 
@@ -330,6 +333,7 @@ async fn test_relinquish_nft_vote_with_invalid_voter_error() -> Result<(), Trans
             &voter_cookie,
             &voter_token_owner_record_cookie,
             &[&nft_cookie1],
+            None,
         )
         .await?;
 


### PR DESCRIPTION
#### Summary

Make it possible to vote with any number of NFTs

#### Solution

`CastNftVote` was updated to support total`voter_weight` through multiple accumulating invocations in different transactions 

#### Out of scope
`UpdateVoterWeight` used to evaluate `voter_weight` for none voting scenarios is still restricted to max 5 NFTs. 
It could be supported in future versions if higher thresholds are needed, however for most of the cases it would be unnecessary cost to calculate the cumulative weight because bookkeeping accoutns would have to be created to preserve state between multiple tx.  