### PR TITLE
NFT Voter: Review feedback

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -25,8 +25,8 @@ show_tree = true # Show inverse dependency trees along with advisories (default:
 arch = "x86_64" # Ignore advisories for CPU architectures other than this one
 os = "linux" # Ignore advisories for operating systems other than this one
 
-[packages]
-source = "all" # "all", "public" or "local"
+# [packages]
+# source = "all" # "all", "public" or "local"
 
 [yanked]
 enabled = false # Warn for yanked crates in Cargo.lock (default: true)

--- a/programs/nft-voter/src/error.rs
+++ b/programs/nft-voter/src/error.rs
@@ -73,4 +73,7 @@ pub enum NftVoterError {
 
     #[msg("VoterWeightRecord must be expired")]
     VoterWeightRecordMustBeExpired,
+
+    #[msg("Cannot configure collection with voting proposals")]
+    CannotConfigureCollectionWithVotingProposals,
 }

--- a/programs/nft-voter/src/error.rs
+++ b/programs/nft-voter/src/error.rs
@@ -70,4 +70,7 @@ pub enum NftVoterError {
 
     #[msg("Invalid VoteRecord for NftVoteRecord")]
     InvalidVoteRecordForNftVoteRecord,
+
+    #[msg("VoterWeightRecord must be expired")]
+    VoterWeightRecordMustBeExpired,
 }

--- a/programs/nft-voter/src/instructions/configure_collection.rs
+++ b/programs/nft-voter/src/instructions/configure_collection.rs
@@ -65,6 +65,11 @@ pub fn configure_collection(
         NftVoterError::InvalidRealmAuthority
     );
 
+    // Changes to the collections config can accidentally tip the scales for outstanding proposals and hence we disallow it
+    if realm.voting_proposal_count > 0 {
+        return err!(NftVoterError::CannotConfigureCollectionWithVotingProposals);
+    }
+
     let collection = &ctx.accounts.collection;
 
     let collection_config = CollectionConfig {

--- a/programs/nft-voter/src/instructions/relinquish_nft_vote.rs
+++ b/programs/nft-voter/src/instructions/relinquish_nft_vote.rs
@@ -9,9 +9,9 @@ use spl_governance_tools::account::dispose_account;
 /// Disposes NftVoteRecord and recovers the rent from the accounts   
 /// It can only be executed when voting on the target Proposal ended or voter withdrew vote from the Proposal
 ///
-/// Note: If a voter votes with NFT and transfers the token then in the current version the new owner can't withdraw the vote
+/// Note: If a voter votes with NFT and transfers the token then in the current version of the program the new owner can't withdraw the vote
 /// In order to support that scenario a change in spl-governance is needed
-/// It would have to support revoke_vote instruction which would take as input VoteWeightRecord with
+/// It would have to support revoke_vote instruction which would take as input VoteWeightRecord with the following values:
 /// weight_action: RevokeVote, weight_action_target: VoteRecord, voter_weight: sum(previous owner NFT weight)
 /// The instruction would decrease the previous voter total VoteRecord.voter_weight by the provided VoteWeightRecord.voter_weight
 /// Once the spl-governance instruction is supported then nft-voter plugin should implement revoke_nft_vote instruction

--- a/programs/nft-voter/src/instructions/relinquish_nft_vote.rs
+++ b/programs/nft-voter/src/instructions/relinquish_nft_vote.rs
@@ -8,6 +8,12 @@ use spl_governance_tools::account::dispose_account;
 
 /// Disposes NftVoteRecord and recovers the rent from the accounts   
 /// It can only be executed when voting on the target Proposal ended or voter withdrew vote from the Proposal
+///
+/// Note: If a voter votes with NFT and transfers the token then in the current version the new owner can't withdraw the vote
+/// In order to support that scenario a change in spl-governance is needed
+/// It would have to support revoke_vote instruction which would take as input VoteWeightRecord with
+/// weight_action: RevokeVote, weight_action_target: VoteRecord, voter_weight: sum(previous owner NFT weight)
+/// The instruction would decrease the previous voter total VoteRecord.voter_weight by the provided VoteWeightRecord.voter_weight
 #[derive(Accounts)]
 pub struct RelinquishNftVote<'info> {
     /// The NFT voting Registrar

--- a/programs/nft-voter/src/instructions/relinquish_nft_vote.rs
+++ b/programs/nft-voter/src/instructions/relinquish_nft_vote.rs
@@ -14,6 +14,8 @@ use spl_governance_tools::account::dispose_account;
 /// It would have to support revoke_vote instruction which would take as input VoteWeightRecord with
 /// weight_action: RevokeVote, weight_action_target: VoteRecord, voter_weight: sum(previous owner NFT weight)
 /// The instruction would decrease the previous voter total VoteRecord.voter_weight by the provided VoteWeightRecord.voter_weight
+/// Once the spl-governance instruction is supported then nft-voter plugin should implement revoke_nft_vote instruction
+/// to supply the required VoteWeightRecord and delete relevant NftVoteRecords
 #[derive(Accounts)]
 pub struct RelinquishNftVote<'info> {
     /// The NFT voting Registrar

--- a/programs/nft-voter/src/instructions/update_voter_weight_record.rs
+++ b/programs/nft-voter/src/instructions/update_voter_weight_record.rs
@@ -35,11 +35,14 @@ pub fn update_voter_weight_record(
     let registrar = &ctx.accounts.registrar;
     let governing_token_owner = &ctx.accounts.voter_weight_record.governing_token_owner;
 
-    // CastVote can't be evaluated using this instruction
-    require!(
-        voter_weight_action != VoterWeightAction::CastVote,
-        NftVoterError::CastVoteIsNotAllowed
-    );
+    match voter_weight_action {
+        // voter_weight for CastVote action can't be evaluated using this instruction
+        VoterWeightAction::CastVote => return err!(NftVoterError::CastVoteIsNotAllowed),
+        VoterWeightAction::CommentProposal
+        | VoterWeightAction::CreateGovernance
+        | VoterWeightAction::CreateProposal
+        | VoterWeightAction::SignOffProposal => {}
+    }
 
     let mut voter_weight = 0u64;
 

--- a/programs/nft-voter/tests/cast_nft_vote.rs
+++ b/programs/nft-voter/tests/cast_nft_vote.rs
@@ -1172,6 +1172,8 @@ async fn test_cast_nft_vote_using_multiple_instructions_with_attempted_sandwiche
         )
         .await?;
 
+    nft_voter_test.bench.advance_clock().await;
+
     // Try relinquish NftVoteRecords to accumulate vote
     nft_voter_test
         .relinquish_nft_vote(

--- a/programs/nft-voter/tests/relinquish_nft_vote.rs
+++ b/programs/nft-voter/tests/relinquish_nft_vote.rs
@@ -1,6 +1,6 @@
 use crate::program_test::nft_voter_test::ConfigureCollectionArgs;
 use gpl_nft_voter::error::NftVoterError;
-use program_test::nft_voter_test::NftVoterTest;
+use program_test::nft_voter_test::{CastNftVoteArgs, NftVoterTest};
 use program_test::tools::assert_nft_voter_err;
 use solana_program_test::*;
 use solana_sdk::transport::TransportError;
@@ -64,6 +64,8 @@ async fn test_relinquish_nft_vote() -> Result<(), TransportError> {
             None,
         )
         .await?;
+
+    nft_voter_test.bench.advance_clock().await;
 
     // Act
 
@@ -165,6 +167,8 @@ async fn test_relinquish_nft_vote_for_proposal_in_voting_state() -> Result<(), T
             &voter_token_owner_record_cookie,
         )
         .await?;
+
+    nft_voter_test.bench.advance_clock().await;
 
     // Act
 
@@ -358,6 +362,95 @@ async fn test_relinquish_nft_vote_with_invalid_voter_error() -> Result<(), Trans
     // Assert
 
     assert_nft_voter_err(err, NftVoterError::InvalidTokenOwnerForVoterWeightRecord);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_relinquish_nft_vote_with_unexpired_vote_weight_record() -> Result<(), TransportError>
+{
+    // Arrange
+    let mut nft_voter_test = NftVoterTest::start_new().await;
+
+    let realm_cookie = nft_voter_test.governance.with_realm().await?;
+
+    let registrar_cookie = nft_voter_test.with_registrar(&realm_cookie).await?;
+
+    let nft_collection_cookie = nft_voter_test.token_metadata.with_nft_collection().await?;
+
+    let max_voter_weight_record_cookie = nft_voter_test
+        .with_max_voter_weight_record(&registrar_cookie)
+        .await?;
+
+    nft_voter_test
+        .with_collection(
+            &registrar_cookie,
+            &nft_collection_cookie,
+            &max_voter_weight_record_cookie,
+            Some(ConfigureCollectionArgs {
+                weight: 10,
+                size: 20,
+            }),
+        )
+        .await?;
+
+    let voter_cookie = nft_voter_test.bench.with_wallet().await;
+
+    let voter_token_owner_record_cookie = nft_voter_test
+        .governance
+        .with_token_owner_record(&realm_cookie, &voter_cookie)
+        .await?;
+
+    let voter_weight_record_cookie = nft_voter_test
+        .with_voter_weight_record(&registrar_cookie, &voter_cookie)
+        .await?;
+
+    let proposal_cookie = nft_voter_test
+        .governance
+        .with_proposal(&realm_cookie)
+        .await?;
+
+    let nft_cookie1 = nft_voter_test
+        .token_metadata
+        .with_nft_v2(&nft_collection_cookie, &voter_cookie, None)
+        .await?;
+
+    let args = CastNftVoteArgs {
+        cast_spl_gov_vote: false,
+    };
+
+    // Cast vote with NFT
+    let nft_vote_record_cookies = nft_voter_test
+        .cast_nft_vote(
+            &registrar_cookie,
+            &voter_weight_record_cookie,
+            &max_voter_weight_record_cookie,
+            &proposal_cookie,
+            &voter_cookie,
+            &voter_token_owner_record_cookie,
+            &[&nft_cookie1],
+            Some(args),
+        )
+        .await?;
+
+    // Act
+
+    let err = nft_voter_test
+        .relinquish_nft_vote(
+            &registrar_cookie,
+            &voter_weight_record_cookie,
+            &proposal_cookie,
+            &voter_cookie,
+            &voter_token_owner_record_cookie,
+            &nft_vote_record_cookies,
+        )
+        .await
+        .err()
+        .unwrap();
+
+    // Assert
+
+    assert_nft_voter_err(err, NftVoterError::VoterWeightRecordMustBeExpired);
 
     Ok(())
 }


### PR DESCRIPTION
#### Summary

Cumulative set of changes based on code review feedback

- Add a comment explaining why NFT vote can't be withdrawn by a new owner if the NFT is transferred and what changes in `spl-governance` are required
- Do not allow changes to NFT collection configurations if there are any proposals in voting state to prevent accidental changes to vote outcomes 
- Reject `RelinquishNftVote` instruction within `VoteWeightRecord` expiration period to prevent attacks when multiple stacked `voter-weight` plugins are used